### PR TITLE
fix second number will be the day number

### DIFF
--- a/src/json-to-ical.js
+++ b/src/json-to-ical.js
@@ -36,7 +36,7 @@ const timeSlice = raw => {
     day: slice2num(8, 10),
     hour: slice2num(11, 13),
     minute: slice2num(14, 16),
-    second: slice2num(8, 10),
+    second: 0,
     isDate: false
   }
 }


### PR DESCRIPTION
In the previous implementation, the data  `start: '2020-06-17 14:30',`  will be parsed as `DTSTART:20200617T143017`, there will be a strange second value.
I think it should change to 00 or slice2num(17, 19) in case the site return a time with seconds like `14:30:00`
And now since there is no second returned, the seconds will be parsed as number 0, and when the Time object constructs, it will get the right 00 as the desired result